### PR TITLE
minor change to respect query strings...

### DIFF
--- a/src/vogue.js
+++ b/src/vogue.js
@@ -101,7 +101,7 @@ VogueClient.prototype.handleMessage = function(message) {
   this.watchFile(match[1]);  
 };
 VogueClient.prototype.watchFile = function(href) {
-  var filename = path.join(options.dir, href.substr(1));
+  var filename = path.join(options.dir, href.substr(1)).split('?')[0];
   fs.stat(filename, function(err, stats) {
     if (err) {
       console.log('Could not read stats for ' + filename);


### PR DESCRIPTION
Hi,

Vogue is absolutely brilliant!  Thank you very much for the idea and the execution.

This change is very minor but it allows for a common technique (common at least for me):  versioning CSS URLs to ensure browsers reload the CSS from the server and not their cache.

When developing sites using Chrome, the browser simply doesn't reload pages when you ask it to.  To work around that, I add random query strings to JS and CSS media, something like "?v=7.236429032432".  That works for dev.  In production, it's even more critical that clients get the correct version, so I tie it to the application version, e.g., "?v=391".

The change simply removes the query string from the watched filename.

Thanks again.

troy
