### PR TITLE
locate stylesheets by rel, not type

### DIFF
--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -41,7 +41,7 @@ function vogue() {
   }
   
   function getLocalStylesheets() {
-    var links = $('link[type="text/css"][href]').filter(isLocal);
+    var links = $('link[rel="stylesheet"][href]').filter(isLocal);
     var stylesheets = {};
     links.each(function() {
       // Match hrefs against stylesheet bases we know of


### PR DESCRIPTION
using rel=stylesheet to locate css is safer for minimalistic html or html5boilerplate.
