### PR TITLE
In projects where jQuery.noConflict() is called, $ is undefined.

### DIFF
--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -37,11 +37,11 @@ function vogue() {
       + (href.indexOf('?') >= 0 ? '&' : '?') 
       + '_vogue_nocache=' 
       + (new Date()).getTime();
-    $(stylesheets[href]).attr('href', newHref);
+    jQuery(stylesheets[href]).attr('href', newHref);
   }
   
   function getLocalStylesheets() {
-    var links = $('link[rel="stylesheet"][href]').filter(isLocal);
+    var links = jQuery('link[rel="stylesheet"][href]').filter(isLocal);
     var stylesheets = {};
     links.each(function() {
       // Match hrefs against stylesheet bases we know of
@@ -56,7 +56,7 @@ function vogue() {
     return stylesheets;
 
     function isLocal() {
-      var href = $(this).attr('href');
+      var href = jQuery(this).attr('href');
 
       var isExternal = true;
       for (var i=0; i<script.bases.length; i++) {


### PR DESCRIPTION
This commit changes references to '$' to the more robust 'jQuery' in vogue-client.js, as it was throwing errors in projects where $ has been redefined.
