### PR TITLE
Fix for css include selector 

### DIFF
--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -41,7 +41,7 @@ function vogue() {
   }
   
   function getLocalStylesheets() {
-    var links = jQuery('link[rel="stylesheet"][href]').filter(isLocal);
+    var links = $('link[type="text/css"][href], link[rel="stylesheet"][href]').filter(isLocal);
     var stylesheets = {};
     links.each(function() {
       // Match hrefs against stylesheet bases we know of


### PR DESCRIPTION
I fixed the jquery selector to work with css includes like this <link rel="stylesheet" href="css/style.css?v=2"> 
