### PR TITLE
Properly handle @import rules

### DIFF
--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -35,7 +35,7 @@
             (href.indexOf("?") >= 0 ? "&" : "?") +
             "_vogue_nocache=" + (new Date).getTime(),
           stylesheet;
-        
+      
       // Check if the appropriate DOM Node is there.
       if (!stylesheets[href].setAttribute) {
         // If the stylesheet is from an @import, remove it
@@ -150,9 +150,15 @@
       // Go through stylesheet rules looking for @import
       var allStyleSheets = document.styleSheets;
       function recursivelyAddImportedStylesheets(styleSheet) {
-        if ( ! styleSheet.rules ) return;
-        for ( var i = 0, rule; rule = styleSheet.rules[i]; i++ ) {
-          if ( rule.constructor == CSSImportRule ) {
+        var rules;
+        // The try {} will catch security errors when trying to get cssRules
+        // from cross domain stylesheets
+        try {
+          rules = styleSheet.rules || styleSheet.cssRules;
+        } catch (e) {}
+        if ( ! rules ) return;
+        for ( var i = 0, rule; rule = rules[i]; i++ ) {
+          if ( rule.href ) {
             var h = rule.href;
             stylesheets[h] = {rel: "stylesheet", href: h};
             imported[h] = {styleSheet: styleSheet, index: i};

--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -41,7 +41,13 @@
         // If the stylesheet is from an @import, remove it
         // as a "rule" and add it as a normal stylesheet
         if (imported[href]) {
-          imported[href].styleSheet.deleteRule(imported[href].index);
+          var styleSheet = imported[href].styleSheet;
+          var index = imported[href].index;
+          // deleteRule is standard way of removing rules, removeRule is for IE
+          if (styleSheet.deleteRule)
+            styleSheet.deleteRule(index);
+          else if (styleSheet.removeRule)
+            styleSheet.removeRule(index);
           delete imported[href];
         }
         

--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -152,20 +152,24 @@
           stylesheets[href] = link;
         }
       }
-
+      
       // Go through stylesheet rules looking for @import
       var allStyleSheets = document.styleSheets;
+      
       function recursivelyAddImportedStylesheets(styleSheet) {
         var rules;
         // The try {} will catch security errors when trying to get cssRules
         // from cross domain stylesheets
+        
         try {
-          rules = styleSheet.rules || styleSheet.cssRules;
+          rules = styleSheet.cssRules || styleSheet.rules;
         } catch (e) {}
+        
         if ( ! rules ) return;
+        
         for ( var i = 0, rule; rule = rules[i]; i++ ) {
           if ( rule.href ) {
-            var h = rule.href;
+            var h = getBase(rule.href) || rule.href;
             stylesheets[h] = {rel: "stylesheet", href: h};
             imported[h] = {styleSheet: styleSheet, index: i};
             recursivelyAddImportedStylesheets(rule.styleSheet);

--- a/src/client/vogue-client.js
+++ b/src/client/vogue-client.js
@@ -132,7 +132,6 @@
       }
 
       var stylesheets = {},
-          reImport = /@import\s+url\(["']?([^"'\)]+)["']?\)/g,
           links = document.getElementsByTagName("link"),
           link, href, matches, content, i, m;
 
@@ -148,29 +147,10 @@
         }
       }
 
-      // Go through all the style tags, looking for @import tags.
-      links = document.getElementsByTagName("style");
-      for (i = 0, m = links.length; i < m; i += 1) {
-        if (isPrintStylesheet(links[i])) continue;
-        content = links[i].text || links[i].textContent;
-        while ((matches = reImport.exec(content))) {
-          link = {
-            rel: "stylesheet",
-            href: matches[1],
-            getAttribute: getProperty
-          };
-          if (isLocalStylesheet(link)) {
-            // Link is local, get the base URL.
-            href = getBase(link.href);
-            if (href !== false) {
-              stylesheets[href] = link;
-            }
-          }
-        }
-      }
-      // Go through stylesheet rules
+      // Go through stylesheet rules looking for @import
       var allStyleSheets = document.styleSheets;
-      function recLoop(styleSheet) {
+      function recursivelyAddImportedStylesheets(styleSheet) {
+        if ( ! styleSheet.rules ) return;
         for ( var i = 0, rule; rule = styleSheet.rules[i]; i++ ) {
           if ( rule.constructor == CSSImportRule ) {
             var h = rule.href;
@@ -255,7 +235,7 @@
       scripts = document.getElementsByTagName("script");
       for (var i=0; i < scripts.length; i++) {
         src = scripts[i].getAttribute("src");
-        if (src.slice(-15) === 'vogue-client.js') break;
+        if (src && src.slice(-15) === 'vogue-client.js') break;
       }
       rootUrl = src.match(/^https?\:\/\/(.*?)\//)[0];
       // There is an optional base argument, that can be used.


### PR DESCRIPTION
I have fixed the vogue client to properly detect @import rules in other stylesheets. The previous method of grep'ing style tags wouldn't work for stylesheets included through link tags. It does this by searching the cssRules of each document.styleSheets recursively to detect CSSImportRules.

These changes have been tested in Chrome, Safari, Firefox and Opera. I'm on a Mac so I've had trouble checking it IE, as I have understood from the vogue website that it's officially supported in IE too. But I've taken precautions to make it as IE safe as possible, so if the code gods are smiling, everything should work fine there too.
